### PR TITLE
Change readme.md file to be compliant with amazon q installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cd ~/CostMinimizer && source .venv/bin/activate && pip install -r requirements.t
 cd ~/CostMinimizer && source .venv/bin/activate && python setup.py develop
 
 # 2.5 Configure the tool
-cd ~/CostMinimizer && source .venv/bin/activate && CostMinimizer --configure
+cd ~/CostMinimizer && source .venv/bin/activate && CostMinimizer --configure --auto-update-conf
 
 # 2.6 Last step, check the current configuration of the tool
 cd ~/CostMinimizer && source .venv/bin/activate && CostMinimizer --configure --ls-conf
@@ -297,8 +297,7 @@ To run all the boto3 calls in the CostMinimizer application, you'll need the fol
         "sts:GetSessionToken",
         "bedrock:Converse",
         "bedrock:InvokeModel",
-        "organizations:List*",
-        "organizations:Describe*",
+        "organizations:DescribeOrganization",
         "ec2:Describe*",
         "ec2:List*",
         "compute-optimizer:Get*"

--- a/src/CostMinimizer/config/config.py
+++ b/src/CostMinimizer/config/config.py
@@ -104,6 +104,10 @@ class Config(Singleton):
     
     def prompt_for_automated_configuration(cls) -> None:
         '''prompt user for automated configuration'''
+        # Check if --auto-update-conf parameter is set
+        if hasattr(cls, 'arguments_parsed') and hasattr(cls.arguments_parsed, 'auto_update_conf') and cls.arguments_parsed.auto_update_conf:
+            return True
+            
         cls.console.print(f'[blue]Tool configuration is not finished.  This appears to be a new installation. [/blue]')
         cls.console.print(f'[blue]Would you like me to attempt an automatic configuartion based on your authentication variables?[/blue]')
         answer = input('Enter [y/n]: ')

--- a/src/CostMinimizer/report_controller/account_discovery_controller.py
+++ b/src/CostMinimizer/report_controller/account_discovery_controller.py
@@ -70,7 +70,7 @@ class AccountDiscoveryController:
 
             return is_payer
         except Exception as e:
-            if 'AWSOrganizationsNotInUseException' in str(e):
+            if 'AWSOrganizationsNotInUseException' in str(e) or 'AccessDeniedException' in str(e):
                 # If the account is not part of an organization, treat it as a standalone account
                 self.appConfig.logger.info("Account is not part of an AWS Organization - treating as standalone account")
                 return False

--- a/src/CostMinimizer/report_controller/account_discovery_controller.py
+++ b/src/CostMinimizer/report_controller/account_discovery_controller.py
@@ -162,6 +162,8 @@ class AccountDiscoveryController:
                 # If we can't access the Support API, it's likely Basic Support
                 if 'SubscriptionRequiredException' in str(e):
                     return 'Basic'
+                elif 'AccessDeniedException' in str(e):
+                    return 'Basic'
                 else:
                     raise e
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Intercept AccessDeniedException when trying to discover Organization, and then do not raise the an exception but consider the account as stand alone
- Check if --auto-update-conf parameter is set, then force prompt_for_automated_configuration() to return True
- modify Readme.md so that Amazon Q chat use --auto-update-conf for the first automatic launch (generative AI adaptation of Readme.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
