### PR TITLE
2025 08 28 csaws update database parameters

### DIFF
--- a/src/CostMinimizer/commands/configure_tooling.py
+++ b/src/CostMinimizer/commands/configure_tooling.py
@@ -680,7 +680,7 @@ class ConfigureToolingCommand:
                     dictionary[key] = new_value  # Replace with your specific update operation
         return dictionary
 
-    def automated_cow_internals_parameters(self) -> dict():
+    def automated_cow_internals_parameters(self) -> dict:
         
         new_dict = self.update_values_recursive(self.appConfig.internals)
         

--- a/src/CostMinimizer/conf/cm_internals.yaml
+++ b/src/CostMinimizer/conf/cm_internals.yaml
@@ -1,9 +1,10 @@
 internals:
   db_fields_to_update:
-    - version
+    - 'version.version'
     - 'genAI.default_provider'
     - 'genAI.default_provider_region'
     - 'genAI.default_genai_model'
+    - 'results_folder.automatic_configuration_from_file_filename'
   boto:
     default_profile_name: CostMinimizer
     default_profile_role: Admin
@@ -75,6 +76,7 @@ internals:
     user_tag_discovery: user_tag_discovery.k2
     user_tag_values_discovery: user_tag_values_discovery.cur
   results_folder:
+    automatic_configuration_from_file_filename: cm_autoconfig.json
     enable_bucket_for_results: False
     bucket_for_results: aws-athena-query-results-{dummy_value}-us-east-1
   genAI:
@@ -82,4 +84,5 @@ internals:
     default_provider_region: us-east-1
     default_genai_model: anthropic.claude-3-5-sonnet-20240620-v1:0
     inference_profile_arn: 
-  version: 0.0.1
+  version: 
+    version: 0.0.1


### PR DESCRIPTION
## THIS IS A BREAKING CHANGE ## 
After the merge you should delete your CostMinimizer.db.  Or edit the table cow_internalsparameters and remove the internals.version key.  This key is superceded by the new internals.version.version key.


*Issue #, if available:
The updates or additions listed in the db_fields_to_update of cm_internals.yaml were not updating or adding correctly.  It is vital for us to be able to add new parameters into a customers configuration after upgrade.  

*Description of changes:*
Updated update_internals_parameters_table_from_yaml_file() method in the database class to update or add an updated key or new key correctly. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
