### PR TITLE
application errored out if json config file was not present

### DIFF
--- a/src/CostMinimizer/config/config.py
+++ b/src/CostMinimizer/config/config.py
@@ -639,6 +639,8 @@ internals:
                 cls.console.print(f"[red]Failed to import config values from file {str(automatic_configuration_import_file)}")
                 cls.logger.info(f"Failed to import config values from file {str(automatic_configuration_import_file)}")
                 raise(e)
+        else:
+            return '{}'
         
         return automatic_configuration_data
 


### PR DESCRIPTION
*Issue #, if available: The application when running in a container did not contain the cm_autoconfig.json file.  There was an error running the app when this file was missing. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
